### PR TITLE
fix: Solve localizing a localized datetime

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -405,7 +405,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                                                              key=lambda reading: reading.date
                                                              .replace(minute=0, second=0, microsecond=0))
             readings_by_hour: dict[datetime, float] = {}
-            if not last_stat_req_hour.tzinfo:
+            if last_stat_req_hour and last_stat_req_hour.tzinfo is None:
                 last_stat_req_hour = TIMEZONE.localize(last_stat_req_hour)
 
             for key, group in grouped_new_readings_by_hour:
@@ -414,9 +414,9 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                     _LOGGER.debug(f"LongTerm Statistics - Skipping {key} since it's partial for the hour")
                     continue
                 if key <= last_stat_req_hour:
-                    _LOGGER.debug(f"LongTerm Statistics -Skipping {key} data since it's already reported")
+                    _LOGGER.debug(f"LongTerm Statistics - Skipping {key} data since it's already reported")
                     continue
-                readings_by_hour[key] = sum(reading.value for reading in group_list)
+                readings_by_hour[key] = sum(reading.value for reading in group)
 
             consumption_metadata = StatisticMetaData(
                 has_mean=False,

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -405,12 +405,15 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                                                              key=lambda reading: reading.date
                                                              .replace(minute=0, second=0, microsecond=0))
             readings_by_hour: dict[datetime, float] = {}
+            if not last_stat_req_hour.tzinfo:
+                last_stat_req_hour = TIMEZONE.localize(last_stat_req_hour)
+
             for key, group in grouped_new_readings_by_hour:
                 group_list = list(group)
                 if len(group_list) < 4:
                     _LOGGER.debug(f"LongTerm Statistics - Skipping {key} since it's partial for the hour")
                     continue
-                if key <= TIMEZONE.localize(last_stat_req_hour):
+                if key <= last_stat_req_hour:
                     _LOGGER.debug(f"LongTerm Statistics -Skipping {key} data since it's already reported")
                     continue
                 readings_by_hour[key] = sum(reading.value for reading in group_list)


### PR DESCRIPTION
## **User description**
Solves #103


___

## **Type**
bug_fix


___

## **Description**
- The PR addresses an issue where `last_stat_req_hour` could be used without timezone information, leading to potential errors in time comparison.
- It adds a condition to check the timezone information of `last_stat_req_hour` and localizes it if necessary using `TIMEZONE.localize`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Ensure Timezone Information for `last_stat_req_hour`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
custom_components/iec/coordinator.py

<li>Added a check to ensure <code>last_stat_req_hour</code> has timezone info before <br>comparison.<br> <li> Localized <code>last_stat_req_hour</code> if it lacks timezone information.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/104/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

