### PR TITLE
fix: iteration over group not working

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -417,7 +417,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 if key <= last_stat_req_hour:
                     _LOGGER.debug(f"LongTerm Statistics - Skipping {key} data since it's already reported")
                     continue
-                readings_by_hour[key] = sum(reading.value for reading in group)
+                readings_by_hour[key] = sum(reading.value for reading in group_list)
 
             consumption_metadata = StatisticMetaData(
                 has_mean=False,


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Corrected the variable used for iteration from `group` to `group_list` in the `_insert_statistics` method to ensure proper summing of readings.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Fix iteration over incorrect variable in statistics insertion</code></dd></summary>
<hr>
      
custom_components/iec/coordinator.py

<li>Fixed the iteration over the wrong variable in the <code>_insert_statistics</code> <br>method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/112/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

