### PR TITLE
feat: optimize cached readings storing by using smart key

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -97,8 +97,17 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
 
     async def _get_readings(self, contract_id: int, device_id: str | int, device_code: str | int, date: datetime,
                             resolution: ReadingResolution):
-        date_key = date.date()
-        key = (contract_id, int(device_id), int(device_code), date_key, resolution)
+
+        date_key = date.strftime("%Y")
+        match resolution:
+            case ReadingResolution.DAILY:
+                date_key += date.strftime("-%m-%d")
+            case ReadingResolution.WEEKLY:
+                date_key += "/" + str(date.isocalendar().week)
+            case ReadingResolution.MONTHLY:
+                date_key += date.strftime("-%m")
+
+        key = (contract_id, int(device_id), date_key)
         reading = self._readings.get(key)
         if not reading:
             try:

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -106,6 +106,9 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 date_key += "/" + str(date.isocalendar().week)
             case ReadingResolution.MONTHLY:
                 date_key += date.strftime("-%m")
+            case _:
+                _LOGGER.warning("Unexpected resolution value")
+                date_key += date.strftime("-%m-%d")
 
         key = (contract_id, int(device_id), date_key)
         reading = self._readings.get(key)

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -229,7 +229,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 # So instead of sending the 1st day of the month, just sending today date
 
                 monthly_report_req_date: datetime = localized_today.replace(hour=1, minute=0,
-                                                                            second=0, microsecond=0)
+                                                                            second=0, microsecond=0) + timedelta(days=1)
 
                 devices = await self._get_devices_by_contract_id(contract_id)
 
@@ -241,7 +241,16 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                                                               ReadingResolution.MONTHLY)
                     if remote_reading:
                         future_consumption[device.device_number] = remote_reading.future_consumption_info
+
+                    if monthly_report_req_date.date() == localized_today.date():
                         daily_readings[device.device_number] = remote_reading.data
+                    else:
+                        this_month_reading = await self._get_readings(contract_id, device.device_number,
+                                                                      device.device_code,
+                                                                      localized_today,
+                                                                      ReadingResolution.MONTHLY)
+                        if this_month_reading:
+                            daily_readings[device.device_number] = this_month_reading.data
 
                     weekly_future_consumption = None
                     if localized_today.day == 1:

--- a/custom_components/iec/sensor.py
+++ b/custom_components/iec/sensor.py
@@ -189,7 +189,7 @@ ELEC_SENSORS: tuple[IecEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
         value_fn=lambda data: data[INVOICE_DICT_NAME].meter_readings[0].reading if (
-                data[INVOICE_DICT_NAME] != EMPTY_INVOICE) else None,
+                data[INVOICE_DICT_NAME] != EMPTY_INVOICE and data[INVOICE_DICT_NAME].meter_readings) else None,
     )
 )
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Optimized the key generation for cached readings in `coordinator.py` to include specific date formats based on the resolution, enhancing the specificity and potential retrieval speed of cached data.
- Improved error handling in `sensor.py` by ensuring that `meter_readings` exists before attempting to access, which prevents potential errors in scenarios where `meter_readings` might be missing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Optimize Cached Readings Key Generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
custom_components/iec/coordinator.py

<li>Modified the key generation logic for cached readings based on the <br>resolution.<br> <li> Added date formatting to include year, month, day, or week number <br>depending on the resolution.<br> <li> Simplified the key tuple by removing <code>device_code</code> and using formatted <br><code>date_key</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/114/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Improve Robustness of Meter Reading Access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
custom_components/iec/sensor.py

<li>Updated the lambda function in <code>_get_reading_by_date</code> to check for the <br>presence of <code>meter_readings</code> before accessing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/114/files#diff-9bbde7209e0ccd939c47898e3459a6b89ddf3b9492fd34c3066337fe019d627c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

