### PR TITLE
Revert "fix: Remove contract status=1 enforcement"

### DIFF
--- a/custom_components/iec/config_flow.py
+++ b/custom_components/iec/config_flow.py
@@ -120,7 +120,7 @@ class IecConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data[CONF_BP_NUMBER] = customer.bp_number
 
                 contracts = await client.get_contracts(customer.bp_number)
-                contract_ids = [int(contract.contract_id) for contract in contracts]
+                contract_ids = [int(contract.contract_id) for contract in contracts if contract.status == 1]
                 if len(contract_ids) == 1:
                     data[CONF_SELECTED_CONTRACTS] = [contract_ids[0]]
                     return self._async_create_iec_entry(data)

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -186,10 +186,10 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
 
         all_contracts: list[Contract] = await self.api.get_contracts(self._bp_number)
         if not self._contract_ids:
-            self._contract_ids = [int(contract.contract_id) for contract in all_contracts]
+            self._contract_ids = [int(contract.contract_id) for contract in all_contracts if contract.status == 1]
 
-        contracts: dict[int, Contract] = {int(c.contract_id): c for c in all_contracts
-                                          if int(c.contract_id) in self._contract_ids}
+        contracts: dict[int, Contract] = {int(c.contract_id): c for c in all_contracts if c.status == 1
+                                          and int(c.contract_id) in self._contract_ids}
         localized_today = TIMEZONE.localize(datetime.today())
         tariff = await self._get_kwh_tariff()
 


### PR DESCRIPTION
Reverts GuyKh/iec-custom-component#119

It seems that the issue was resolved by itself.
I'll keep the `status == 1` for now since I'm not sure what other statuses mean