### PR TITLE
fix: Issue when there's no connection size found

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -658,12 +658,15 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         if connection_size:
             power_size = await self._get_power_size(connection_size)
         else:
+            power_size = 0.0
             _LOGGER.warning("Couldn't get Connection Size")
 
         if phase_count:
             distribution_tariff = await self._get_distribution_tariff(phase_count)
             delivery_tariff = await self._get_delivery_tariff(phase_count)
         else:
+            distribution_tariff = 0.0
+            delivery_tariff = 0.0
             if connection_size:
                 _LOGGER.warning("Couldn't get Phase Count")
 

--- a/custom_components/iec/manifest.json
+++ b/custom_components/iec/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/guykh/iec-custom-component/issues",
   "loggers": ["iec_api"],
   "requirements": ["iec-api==0.4.3"],
-  "version": "0.0.33-b2"
+  "version": "0.0.33-b3"
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed an issue where `distribution_tariff` and `delivery_tariff` were not set when `phase_count` was unavailable by assigning default values.
- Added a warning log message for missing `Phase Count` when `connection_size` is present.
- Updated the component version in `manifest.json` to `0.0.33-b3`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Handle missing phase count by setting default tariffs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/iec/coordinator.py

<li>Set default values for <code>distribution_tariff</code> and <code>delivery_tariff</code> when <br><code>phase_count</code> is not available.<br> <li> Added logging warning for missing <code>Phase Count</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/164/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump version to 0.0.33-b3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/iec/manifest.json

- Updated the version from `0.0.33-b2` to `0.0.33-b3`.



</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/164/files#diff-21a6d1c0910160ff96d249d1b7bd682b95fd4d26ac00049862148b4f10ad78ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

