### PR TITLE
If device is not supported, gracefully ignore it #184

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -629,11 +629,18 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         if not is_private_producer:
             try:
                 devices_by_id: Devices = await self._get_devices_by_device_id(device_number)
-                last_meter_read = int(devices_by_id.counter_devices[0].last_mr)
-                last_meter_read_date = devices_by_id.counter_devices[0].last_mr_date
-                phase_count = devices_by_id.counter_devices[0].connection_size.phase
-                connection_size = (devices_by_id.counter_devices[0].
-                                    connection_size.representative_connection_size)
+
+                counter_devices = devices_by_id.counter_devices
+
+                if counter_devices is not None:
+                    first_counter_device = counter_devices[0]
+                    connection_size = first_counter_device.connection_size
+
+                    last_meter_read = int(first_counter_device.last_mr)
+                    last_meter_read_date = first_counter_device.last_mr_date
+                    phase_count = first_counter_device.connection_size.phase
+                    connection_size = connection_size.representative_connection_size
+                    
             except Exception as e:
                 _LOGGER.warning("Failed to fetch data from devices_by_id, falling back to Masa API", e)
                 _LOGGER.debug(f"DevicesById Response: {devices_by_id}")


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Added a check to ensure `counter_devices` is not `None` before accessing its elements, preventing potential errors.
- Refactored the code to handle unsupported devices more gracefully by logging a warning and falling back to the Masa API.
- Improved the robustness of the `_estimate_bill` method by ensuring it does not fail when encountering unsupported devices.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Gracefully handle unsupported devices in billing estimation</code></dd></summary>
<hr>

custom_components/iec/coordinator.py

<li>Added a check for <code>counter_devices</code> being not <code>None</code> before accessing its <br>elements.<br> <li> Refactored code to handle unsupported devices gracefully.<br> <li> Improved error handling by logging a warning and falling back to an <br>alternative API.<br>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/185/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+12/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information