### PR TITLE
feat: Add RetryAfter to fetch errors (2025.12+)

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -808,7 +808,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         except Exception as err:
             _LOGGER.error("Failed updating data. Exception: %s", err)
             _LOGGER.error(traceback.format_exc())
-            raise UpdateFailed("Failed Updating IEC data") from err
+            raise UpdateFailed("Failed Updating IEC data", retry_after=60) from err
 
     async def _insert_statistics(self, contract_id: int, is_smart_meter: bool) -> None:
         if not is_smart_meter:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `retry_after` parameter to UpdateFailed exception

- Set retry delay to 60 seconds on data update failures

- Enables Home Assistant to respect retry timing for IEC data fetches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Data Update Error"] -- "raises UpdateFailed" --> B["UpdateFailed with retry_after=60"]
  B -- "signals to HA" --> C["Retry after 60 seconds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Add retry_after parameter to UpdateFailed exception</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/iec/coordinator.py

<ul><li>Modified exception handling in <code>_async_update_data</code> method<br> <li> Added <code>retry_after=60</code> parameter to <code>UpdateFailed</code> exception<br> <li> Enables Home Assistant coordinator to respect retry timing on fetch <br>failures</ul>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/293/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

