### PR TITLE
fix: Statistics filtering partial data

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -988,9 +988,12 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
 
             for key, group in grouped_new_readings_by_hour:
                 group_list = list(group)
-                if len(group_list) < 4:
+                # Apply 4 listings per hour check only for days less than 1 month old
+                one_month_ago = localized_today - timedelta(days=30)
+                if key.date() >= one_month_ago.date() and len(group_list) < 4:
                     _LOGGER.debug(
-                        f"[IEC Statistics] LongTerm Statistics - Skipping {key} since it's partial for the hour"
+                        f"[IEC Statistics] LongTerm Statistics - Skipping {key} since it's partial for the hour "
+                        f"(data is less than 1 month old and has only {len(group_list)} readings)"
                     )
                     continue
                 if key <= last_stat_req_hour:


### PR DESCRIPTION
### **PR Type**
Bug fix
Fixes #301 

___

### **Description**
- Modified statistics filtering to only apply 4-readings-per-hour check for recent data

- Excludes data older than 1 month from partial data filtering

- Enhanced debug logging with actual reading count information


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Grouped readings by hour"] --> B["Check if data < 1 month old"]
  B -->|Yes and < 4 readings| C["Skip as partial data"]
  B -->|No or >= 4 readings| D["Include in statistics"]
  C --> E["Enhanced debug log"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Add age-based filtering for partial statistics data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/iec/coordinator.py

<ul><li>Added 1-month age check before applying 4-readings-per-hour validation<br> <li> Only filters partial data for recent readings, allowing older <br>incomplete hours<br> <li> Enhanced debug message to include actual reading count for skipped <br>entries<br> <li> Improved data quality by preventing loss of historical data</ul>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/302/files#diff-6ce6bbf13b6589ae1f4611633e1444dd2f21e3bf539c5cc80f3997b7ef9b40b5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

