### PR TITLE
security: Remove debug service exposing coordinator data

### DIFF
--- a/custom_components/iec/__init__.py
+++ b/custom_components/iec/__init__.py
@@ -29,17 +29,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Register the debug service
-    async def handle_debug_get_coordinator_data(call) -> None:  # noqa: ANN001 ARG001
-        # Log or return coordinator data
-        data = iec_coordinator.data
-        _LOGGER.info("Coordinator data: %s", data)
-        hass.bus.async_fire("custom_component_debug_event", {"data": data})
-
-    hass.services.async_register(
-        DOMAIN, "debug_get_coordinator_data", handle_debug_get_coordinator_data
-    )
-
     return True
 
 


### PR DESCRIPTION
### **User description**
## Summary

Remove the debug service `debug_get_coordinator_data` which was exposing all coordinator data via a public Home Assistant service.

## Security Concern

The debug service was firing events with all coordinator data, which includes:
- Customer information
- JWT tokens
- Billing data
- Meter readings

This is a privacy concern in production environments.

## Change

Removed the debug service registration and handler from `__init__.py`.


___

### **PR Type**
Bug fix


___

### **Description**
- Removes debug service exposing sensitive coordinator data

- Eliminates privacy risk from customer info, JWT tokens, billing data

- Prevents unauthorized access to meter readings via public service


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Debug Service Handler"] -- "removed" --> B["Service Registration"]
  B -- "eliminates" --> C["Exposed Coordinator Data"]
  C -- "includes" --> D["Sensitive Info:<br/>Tokens, Billing, Meters"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Remove debug service and coordinator data exposure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/iec/__init__.py

<ul><li>Removed <code>handle_debug_get_coordinator_data</code> async function<br> <li> Removed service registration call for <code>debug_get_coordinator_data</code><br> <li> Eliminated event firing that exposed all coordinator data<br> <li> Cleaned up 11 lines of debug service code</ul>


</details>


  </td>
  <td><a href="https://github.com/GuyKh/iec-custom-component/pull/319/files#diff-282562c4ab8fcd18fa9d9965d784bd58f2d7851e85501a5f5bc97370762e4c32">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

