### PR TITLE
fix: Add delay between statistics tasks to prevent API flooding

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -552,6 +552,9 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         for contract_id in self._contract_ids:
             # Because IEC API provides historical usage/cost with a delay of a couple of days
             # we need to insert data into statistics.
+            # Add small delay between tasks to avoid API flooding
+            if self._contract_ids.index(contract_id) > 0:
+                await asyncio.sleep(1)
             self.hass.async_create_task(
                 self._insert_statistics(
                     contract_id, contracts.get(contract_id).smart_meter


### PR DESCRIPTION
## Summary

Add a small delay between spawning statistics tasks to prevent API rate limiting.

## Problem

When multiple contracts exist, the coordinator spawns statistics tasks concurrently using `async_create_task()`. This can cause API rate limiting or flooding when there are many contracts.

## Solution

Added a 1-second delay between starting each statistics task to space out API requests and prevent rate limiting.