### PR TITLE
fix: bump py-iec-api to 0.5.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This is a Home Assistant custom component for the Israel Electric Corporation (I
 
 - **Python**: 3.12+
 - **Home Assistant**: 2025.1.4+
-- **iec-api**: 0.5.3 (Python client for IEC API)
+- **iec-api**: 0.5.4 (Python client for IEC API)
 - **Linting**: ruff (with Home Assistant rules)
 - **Type Checking**: mypy
 

--- a/custom_components/iec/manifest.json
+++ b/custom_components/iec/manifest.json
@@ -8,6 +8,6 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guykh/iec-custom-component/issues",
     "loggers": ["iec_api"],
-    "requirements": ["iec-api==0.5.3"],
+    "requirements": ["iec-api==0.5.4"],
     "version": "0.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog>=6.8.2
 homeassistant==2025.1.4
-iec-api==0.5.3
+iec-api==0.5.4
 pip>=21.0
 ruff>=0.5.6


### PR DESCRIPTION
## Summary
- Bump py-iec-api from 0.5.3 to 0.5.4
- This version includes the fix for `cryptography>=44.0.0` (instead of `<45.0.0`) for forward compatibility with cryptography 46.x in 2026.2.2

## Files changed
- `requirements.txt`: iec-api==0.5.3 → iec-api==0.5.4
- `custom_components/iec/manifest.json`: requirements updated
- `AGENTS.md`: version updated in docs