### PR TITLE
Fix coordinator unloading HA-owned aiohttp session

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -114,7 +114,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._readings = {}
         self._account_id: str | None = None
         self._connection_size: str | None = None
-        self._api_session = aiohttp_client.async_create_clientsession(
+        self._api_session = aiohttp_client.async_get_clientsession(
             hass, family=socket.AF_INET
         )
         self.api = IecClient(
@@ -139,8 +139,6 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             self._dummy_listener_unsub()
             self._dummy_listener_unsub = None
         await self.async_shutdown()
-        if not self._api_session.closed:
-            await self._api_session.close()
         _LOGGER.info("Coordinator unloaded successfully.")
 
     async def _get_devices_by_contract_id(self, contract_id) -> list[Device]:


### PR DESCRIPTION
## Summary
- switch `IecApiCoordinator` to Home Assistant's shared aiohttp session via `async_get_clientsession`
- remove manual session close in `async_unload` for the HA-owned session
- preserve existing unload/shutdown flow and logging

## Validation
- `ruff check .`
- `ruff format .`
- `./scripts/lint`

Closes #332
