### PR TITLE
Fix: Use EnergyConverter.UNIT_CLASS for unit_class instead of EnergyConverter

### DIFF
--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -43,6 +43,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.unit_conversion import EnergyConverter
 from iec_api.iec_client import IecClient
 from iec_api.models.contract import Contract
 from iec_api.models.device import Devices
@@ -1638,7 +1639,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "has_mean": False,
                 "has_sum": True,
                 "mean_type": StatisticMeanType.NONE,  # type: ignore[typeddict-item]
-                "unit_class": "energy",
+                "unit_class": EnergyConverter.UNIT_CLASS,
                 "name": f"IEC Meter {device.device_number} Consumption",
                 "source": DOMAIN,
                 "statistic_id": consumption_statistic_id,
@@ -1660,7 +1661,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "has_mean": False,
                 "has_sum": True,
                 "mean_type": StatisticMeanType.NONE,  # type: ignore[typeddict-item]
-                "unit_class": "energy",
+                "unit_class": EnergyConverter.UNIT_CLASS,
                 "name": f"IEC Meter {device.device_number} Production",
                 "source": DOMAIN,
                 "statistic_id": production_statistic_id,

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -41,7 +41,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_TOKEN, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.util.unit_conversion import EnergyConverter
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from iec_api.iec_client import IecClient
@@ -1639,7 +1638,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "has_mean": False,
                 "has_sum": True,
                 "mean_type": StatisticMeanType.NONE,  # type: ignore[typeddict-item]
-                "unit_class": EnergyConverter,  # type: ignore[typeddict-item]
+                "unit_class": "energy",
                 "name": f"IEC Meter {device.device_number} Consumption",
                 "source": DOMAIN,
                 "statistic_id": consumption_statistic_id,
@@ -1661,7 +1660,7 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "has_mean": False,
                 "has_sum": True,
                 "mean_type": StatisticMeanType.NONE,  # type: ignore[typeddict-item]
-                "unit_class": EnergyConverter,  # type: ignore[typeddict-item]
+                "unit_class": "energy",
                 "name": f"IEC Meter {device.device_number} Production",
                 "source": DOMAIN,
                 "statistic_id": production_statistic_id,


### PR DESCRIPTION
## Proposed change
This PR fixes a breaking change in Home Assistant recorder statistics API.

`StatisticMetaData` now expects `unit_class` to be a string (`"energy"`) or `None`, instead of passing the converter class directly (`EnergyConverter`).

The old code caused the following error after HA 2025.10 / 2026.x:
Unsupported unit_class: '<class 'homeassistant.util.unit_conversion.EnergyConverter'>'

This affects both `consumption_metadata` and `production_metadata`.

### Changes
- Replaced `EnergyConverter` with the string `"energy"` in both consumption and production metadata.
- Removed unnecessary `# type: ignore[typeddict-item]` comments.

### Reference
- Official HA blog post: https://developers.home-assistant.io/blog/2025/10/16/recorder-statistics-api-changes/

### Testing
Tested on HA 2026.x — the error no longer appears and statistics are inserted correctly.