### PR TITLE
fix(translations): replace unresolved key references with literal strings

### DIFF
--- a/custom_components/iec/translations/en.json
+++ b/custom_components/iec/translations/en.json
@@ -106,7 +106,7 @@
                 "description": "Select which contract to use"
             },
             "reauth_confirm": {
-                "title": "[%key:common::config_flow::title::reauth%]",
+                "title": "Reauthenticate integration",
                 "description": "Confirm your User ID and select preferred OTP method",
                 "data": {
                     "user_id": "User ID",
@@ -122,15 +122,15 @@
             }
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
             "invalid_id": "Invalid Israeli ID",
             "no_contracts": "You should select at least one contract",
             "no_active_contracts": "No active contracts found"
         },
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+            "already_configured": "Service is already configured",
+            "reauth_successful": "Re-authentication was successful"
         }
     }
 }

--- a/custom_components/iec/translations/he.json
+++ b/custom_components/iec/translations/he.json
@@ -106,7 +106,7 @@
                 "description": "בחרו באיזה חשבון חוזה להשתמש"
             },
             "reauth_confirm": {
-                "title": "[%key:common::config_flow::title::reauth%]",
+                "title": "אימות מחדש",
                 "description": "אשרו את תעודת הזהות ובחרו את שיטת קבלת הקוד החד-פעמי",
                 "data": {
                     "user_id": "מזהה לקוח",
@@ -122,15 +122,15 @@
             }
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "cannot_connect": "ההתחברות נכשלה",
+            "invalid_auth": "אימות לא חוקי",
             "invalid_id": "תעודת זהות לא תקנית",
             "no_contracts": "נא לבחור לפחות חוזה אחד",
             "no_active_contracts": "לא נמצאו חוזים פעילים"
         },
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+            "already_configured": "השירות כבר מוגדר",
+            "reauth_successful": "האימות מחדש הצליח"
         }
     }
 }


### PR DESCRIPTION
The [%key:common::...] syntax is only resolved by the HA core build system and does not work in custom integrations, causing raw keys like [%key:common::config_flow::abort::reauth_successful%] to be displayed to users instead of the actual translated text.