### PR TITLE
Phase 1: .gitignore + CI fix for stacked PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - "main"
   pull_request:
-    branches:
-      - "main"
 
 jobs:
   ruff:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - "main"
   pull_request:
-    branches:
-      - "main"
 
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ config/*
 .claude/
 .opencode/
 .codex/
+.planning/
+token-optimizer/


### PR DESCRIPTION
Adds .planning/ and token-optimizer/ to .gitignore. Enables CI for stacked PRs by removing branch restriction from pull_request trigger.