### PR TITLE
Fix backstream data for private producers and add consumption since last invoice sensor

### DIFF
--- a/custom_components/iec/bill.py
+++ b/custom_components/iec/bill.py
@@ -13,6 +13,7 @@ from typing import Any
 from iec_api.models.remote_reading import (
     FutureConsumptionInfo,
     MeterReadingData,
+    ReadingResolution,
     RemoteReadingResponse,
 )
 
@@ -80,6 +81,50 @@ def _build_backstream_totals(
         "total_back_stream_for_period": future_info.future_back_stream,
         "total_export": future_info.total_export,
     }
+
+
+def _needs_future_consumption_fallback(
+    future_consumption: dict[str, FutureConsumptionInfo | None],
+    backstream_meters: dict[str, bool],
+    backstream_totals: dict[str, dict[str, float | None]],
+    device_number: str,
+) -> bool:
+    """Return whether a fallback reading window is needed for future consumption.
+
+    The IEC API returns zeroed backstream fields in the current month's monthly
+    aggregation even for bidirectional meters, so a backstream meter whose
+    monthly export came back empty must fall back to another reading window.
+    """
+    if not future_consumption.get(device_number):
+        return True
+    return bool(
+        backstream_meters.get(device_number)
+        and not backstream_totals.get(device_number, {}).get("total_export")
+    )
+
+
+def _future_consumption_candidate_dates(
+    today: datetime,
+) -> list[tuple[datetime, ReadingResolution]]:
+    """Return fallback windows to probe for future consumption data, newest first.
+
+    The IEC API does not always publish export data for the current period, so
+    progressively older windows are probed: the last three days, then the most
+    recent completed week (last Sunday; two Sundays ago when today is Sunday),
+    then the first of the current month (or the first of the previous month
+    when today is the first).
+    """
+    last_sunday = today - timedelta(days=today.weekday() + 1)
+    first_of_month = today.replace(day=1)
+    if today.day == 1:
+        first_of_month = (first_of_month - timedelta(days=1)).replace(day=1)
+    return [
+        (today, ReadingResolution.DAILY),
+        (today - timedelta(days=1), ReadingResolution.DAILY),
+        (today - timedelta(days=2), ReadingResolution.DAILY),
+        (last_sunday, ReadingResolution.WEEKLY),
+        (first_of_month, ReadingResolution.MONTHLY),
+    ]
 
 
 def _select_meter_data(

--- a/custom_components/iec/bill.py
+++ b/custom_components/iec/bill.py
@@ -40,11 +40,16 @@ def _is_backstream_meter_kind(meter_kind: Any) -> bool:
         return int(normalized) == 2
 
     lowered = normalized.lower()
-    return lowered in {"backstream", "דו כיווני"}
+    return lowered in {"backstream", "דו כיווני", "דו-כיווני"}
 
 
 def _map_meter_kind_to_remote_reading_param(meter_kind: Any) -> str:
-    """Translate IEC meter kind to the expected parameter for remote reading API."""
+    """Translate IEC meter kind to the expected parameter for remote reading API.
+
+    Only "Consumption" and "Backstream" are valid API parameters. Hebrew and
+    English inputs are normalized to these two options; unknown values default
+    to "Consumption".
+    """
     if meter_kind is None:
         return ""
 
@@ -57,10 +62,21 @@ def _map_meter_kind_to_remote_reading_param(meter_kind: Any) -> str:
 
     METER_KIND_MAPPING = {
         "צריכה": "Consumption",
-        "דו כיווני": "BackStream",
+        "דו כיווני": "Backstream",
+        "דו-כיווני": "Backstream",
     }
 
-    return METER_KIND_MAPPING.get(normalized, normalized)
+    mapped = METER_KIND_MAPPING.get(normalized)
+    if mapped is not None:
+        return mapped
+
+    lowered = normalized.lower()
+    if lowered == "consumption":
+        return "Consumption"
+    if lowered == "backstream":
+        return "Backstream"
+
+    return "Consumption"
 
 
 def _build_backstream_totals(

--- a/custom_components/iec/bill.py
+++ b/custom_components/iec/bill.py
@@ -180,8 +180,12 @@ def _get_invoice_reading_dates(
     """Get the last invoice date and from date for RemoteReadingRange API call.
 
     Returns: (last_invoice_date, from_date) tuple.
-    - last_invoice_date: The lastDate of the most recent invoice where lastDate <= today.
-    - from_date: The toDate of the next invoice after that (or today if none exists).
+    - last_invoice_date: The day after the most recent invoice's fullDate
+      (full_date + 1 day), where full_date <= today. IEC only returns real
+      (non-zeroed) export data for the current period when lastInvoiceDate is
+      set to this value; sending the period start zeroes it out.
+    - from_date: The toDate of the next invoice after that (or today if none
+      exists).
     """
     if not invoices:
         return None, None
@@ -190,7 +194,7 @@ def _get_invoice_reading_dates(
 
     sorted_invoices = sorted(
         invoices,
-        key=lambda inv: _parse_invoice_last_date(inv.last_date) or date.min,
+        key=lambda inv: inv.full_date.date() if inv.full_date else date.min,
         reverse=True,
     )
 
@@ -198,9 +202,11 @@ def _get_invoice_reading_dates(
     from_date_obj = None
 
     for i, invoice in enumerate(sorted_invoices):
-        parsed_last_date = _parse_invoice_last_date(invoice.last_date)
-        if parsed_last_date and parsed_last_date <= today:
-            last_invoice_date_obj = datetime.combine(parsed_last_date, time.min)
+        full_date = invoice.full_date
+        if full_date and full_date.date() <= today:
+            last_invoice_date_obj = datetime.combine(
+                full_date.date() + timedelta(days=1), time.min
+            )
             if i + 1 < len(sorted_invoices):
                 to_date = sorted_invoices[i + 1].to_date
                 if isinstance(to_date, datetime):

--- a/custom_components/iec/bill.py
+++ b/custom_components/iec/bill.py
@@ -22,33 +22,13 @@ from .const import EMPTY_INVOICE
 _LOGGER = logging.getLogger(__name__)
 
 
-def _is_backstream_meter_kind(meter_kind: Any) -> bool:
-    """Return whether the IEC meter kind represents bidirectional export."""
-    if meter_kind is None:
-        return False
-
-    if isinstance(meter_kind, int):
-        return meter_kind == 2
-
-    normalized = str(
-        meter_kind.value if hasattr(meter_kind, "value") else meter_kind
-    ).strip()
-    if not normalized:
-        return False
-
-    if normalized.isdigit():
-        return int(normalized) == 2
-
-    lowered = normalized.lower()
-    return lowered in {"backstream", "דו כיווני", "דו-כיווני"}
-
-
 def _map_meter_kind_to_remote_reading_param(meter_kind: Any) -> str:
     """Translate IEC meter kind to the expected parameter for remote reading API.
 
     Only "Consumption" and "Backstream" are valid API parameters. Hebrew and
-    English inputs are normalized to these two options; unknown values default
-    to "Consumption".
+    English inputs are normalized to these two options; the numeric values
+    returned by the API (1 = Consumption, 2 = Backstream) are translated the
+    same way. Unknown values default to "Consumption".
     """
     if meter_kind is None:
         return ""
@@ -59,6 +39,9 @@ def _map_meter_kind_to_remote_reading_param(meter_kind: Any) -> str:
 
     if not normalized:
         return ""
+
+    if normalized.isdigit():
+        return "Backstream" if int(normalized) == 2 else "Consumption"
 
     METER_KIND_MAPPING = {
         "צריכה": "Consumption",
@@ -77,6 +60,11 @@ def _map_meter_kind_to_remote_reading_param(meter_kind: Any) -> str:
         return "Backstream"
 
     return "Consumption"
+
+
+def _is_backstream_meter_kind(meter_kind: Any) -> bool:
+    """Return whether the IEC meter kind represents bidirectional export."""
+    return _map_meter_kind_to_remote_reading_param(meter_kind) == "Backstream"
 
 
 def _build_backstream_totals(

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -21,20 +21,24 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from iec_api.iec_client import IecClient
 from iec_api.models.contract import Contract
 from iec_api.models.device import Devices
+from iec_api.models.device_in import DeviceInDevice
 from iec_api.models.exceptions import IECError
 from iec_api.models.jwt import JWT
 from iec_api.models.remote_reading import (
     FutureConsumptionInfo,
     PeriodConsumption,
     ReadingResolution,
+    RemoteReadingResponse,
 )
 
 from .bill import (
     _build_backstream_totals,
     _calculate_estimated_bill,
     _extract_valid_future_consumption,
+    _future_consumption_candidate_dates,
     _get_invoice_reading_dates,
     _is_backstream_meter_kind,
+    _needs_future_consumption_fallback,
     _select_meter_data,
 )
 from .commons import TIMEZONE
@@ -77,6 +81,50 @@ from .data_fetcher import IecDataFetcher
 from .statistics import insert_statistics
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _probe_future_consumption(
+    fetcher: IecDataFetcher,
+    contract_id: int,
+    device: DeviceInDevice,
+    today_reading_key: str,
+    today: datetime,
+    is_backstream: bool,
+) -> tuple[FutureConsumptionInfo | None, RemoteReadingResponse | None]:
+    """Probe progressively older windows for future consumption data.
+
+    The IEC API does not always publish export data for the current period,
+    so progressively older windows are probed (see
+    ``_future_consumption_candidate_dates``). The newest valid candidate is
+    kept as a baseline; for backstream meters, candidates whose export data
+    was zeroed by the API are skipped in favour of older windows.
+    """
+    fallback_fc: FutureConsumptionInfo | None = None
+    fallback_reading: RemoteReadingResponse | None = None
+    for req_date, resolution in _future_consumption_candidate_dates(today):
+        candidate_reading = None
+        if req_date == today:
+            candidate_reading = fetcher._today_readings.get(today_reading_key)
+        if candidate_reading is None:
+            candidate_reading = await fetcher._get_readings(
+                contract_id,
+                device.device_number,
+                device.device_code,
+                req_date,
+                resolution,
+                device.meter_kind,
+            )
+        candidate_fc = _extract_valid_future_consumption(candidate_reading)
+        if not candidate_fc:
+            continue
+        if fallback_fc is None:
+            fallback_fc = candidate_fc
+            fallback_reading = candidate_reading
+        if not is_backstream or candidate_fc.total_export:
+            fallback_fc = candidate_fc
+            fallback_reading = candidate_reading
+            break
+    return fallback_fc, fallback_reading
 
 
 class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -618,67 +666,45 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                             )
 
                     # fallbacks for future consumption since IEC api is broken :/
-                    if not future_consumption.get(device.device_number):
-                        today_future_consumption = _extract_valid_future_consumption(
-                            self._fetcher._today_readings.get(today_reading_key),
-                        )
-                        _LOGGER.debug(
-                            "Today's future consumption extraction result: %s",
-                            today_future_consumption,
+                    if _needs_future_consumption_fallback(
+                        future_consumption,
+                        backstream_meters,
+                        backstream_totals,
+                        device.device_number,
+                    ):
+                        fallback_fc, fallback_reading = await _probe_future_consumption(
+                            self._fetcher,
+                            contract_id,
+                            device,
+                            today_reading_key,
+                            localized_today,
+                            backstream_meters[device.device_number],
                         )
 
-                        if today_future_consumption:
-                            future_consumption[device.device_number] = (
-                                today_future_consumption
-                            )
+                        if fallback_fc:
+                            future_consumption[device.device_number] = fallback_fc
                             backstream_totals[device.device_number] = (
-                                _build_backstream_totals(today_future_consumption)
+                                _build_backstream_totals(fallback_fc)
                             )
-                        else:
-                            req_date = localized_today - timedelta(days=2)
-                            two_days_ago_reading = await self._fetcher._get_readings(
-                                contract_id,
-                                device.device_number,
-                                device.device_code,
-                                req_date,
-                                ReadingResolution.MONTHLY,
-                                device.meter_kind,
-                            )
-                            two_days_ago_future_consumption = (
-                                _extract_valid_future_consumption(
-                                    two_days_ago_reading,
-                                )
-                            )
-                            two_days_ago_meter = _select_meter_data(
-                                two_days_ago_reading,
+                            fallback_meter = _select_meter_data(
+                                fallback_reading,
                                 device.device_number,
                                 device.device_code,
                             )
-
-                            if two_days_ago_meter and not daily_readings.get(
+                            if fallback_meter and not daily_readings.get(
                                 device.device_number
                             ):
                                 daily_readings[device.device_number] = (
-                                    two_days_ago_meter.period_consumptions
+                                    fallback_meter.period_consumptions
                                 )
-
-                            if two_days_ago_future_consumption:
-                                future_consumption[device.device_number] = (
-                                    two_days_ago_future_consumption
-                                )
-                                backstream_totals[device.device_number] = (
-                                    _build_backstream_totals(
-                                        two_days_ago_future_consumption
-                                    )
-                                )
-                            else:
-                                _LOGGER.warning(
-                                    "Failed fetching FutureConsumption, data in IEC API is corrupted"
-                                )
-                                future_consumption[device.device_number] = None
-                                backstream_totals[device.device_number] = (
-                                    _build_backstream_totals(None)
-                                )
+                        else:
+                            _LOGGER.warning(
+                                "Failed fetching FutureConsumption, data in IEC API is corrupted"
+                            )
+                            future_consumption[device.device_number] = None
+                            backstream_totals[device.device_number] = (
+                                _build_backstream_totals(None)
+                            )
 
                     try:
                         (

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -564,8 +564,13 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                             future_consumption[device.device_number] = (
                                 monthly_future_consumption
                             )
+                        # Classify from the request-side kind (contract's
+                        # private-producer flag). The response `meterKind`
+                        # flips between 1 and 2 for the same meter depending
+                        # on the queried period, so it is not a reliable
+                        # indicator of a bidirectional meter.
                         backstream_meters[device.device_number] = (
-                            _is_backstream_meter_kind(meter.meter_kind)
+                            _is_backstream_meter_kind(device.meter_kind)
                         )
                         backstream_totals[device.device_number] = (
                             _build_backstream_totals(monthly_future_consumption)

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -554,19 +554,20 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                         reading_type.name,
                         reading_date,
                     )
-                    # Use invoice-based date for MONTHLY readings, otherwise use computed date
-                    # But don't override when we specifically want current month data (first of current month)
+                    # IEC returns zeroed export (backstream) data for the
+                    # current period unless lastInvoiceDate is the day after
+                    # the last invoice, so always pass it for MONTHLY readings;
+                    # fromDate stays the first of the current month.
                     assert reading_date is not None
                     actual_reading_date = datetime.combine(reading_date, time.min)
                     actual_last_invoice_date = None
-                    if (
-                        reading_type == ReadingResolution.MONTHLY
-                        and from_date
-                        and last_invoice_date
-                        and reading_date != localized_first_of_month.date()
-                    ):
-                        actual_reading_date = from_date
+                    if reading_type == ReadingResolution.MONTHLY and last_invoice_date:
                         actual_last_invoice_date = last_invoice_date
+                        if (
+                            from_date
+                            and reading_date != localized_first_of_month.date()
+                        ):
+                            actual_reading_date = from_date
 
                     remote_reading = await self._fetcher._get_readings(
                         contract_id,

--- a/custom_components/iec/data_fetcher.py
+++ b/custom_components/iec/data_fetcher.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from iec_api.iec_client import IecClient
+from iec_api.models.contract import Contract
 from iec_api.models.device import Device, Devices
 from iec_api.models.device_in import DeviceInDevice
 from iec_api.models.exceptions import IECError
@@ -31,6 +32,7 @@ from iec_api.models.remote_reading import (
 
 from .bill import _map_meter_kind_to_remote_reading_param, _select_meter_data
 from .commons import find_reading_by_date
+from .const import CONF_BP_NUMBER, CONF_BP_NUMBER_TO_CONTRACT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +64,7 @@ class IecDataFetcher:
 
         self._today_readings: dict[str, RemoteReadingResponse] = {}
         self._devices_by_contract_id: dict[int, list[DeviceInDevice]] = {}
+        self._contracts_by_bp_number: dict[str, list[Contract]] = {}
         self._last_meter_reading: dict[tuple[int, int], MeterReading] = {}
         self._devices_by_meter_id: dict[str, Devices] = {}
         self._delivery_tariff_by_phase: dict[int, float] = {}
@@ -113,6 +116,7 @@ class IecDataFetcher:
                 api_devices: list[Device] | None = await self._api_call(
                     self.api.get_devices(contract_id_normalized)
                 )
+                meter_kind = await self._get_meter_kind_for_contract(contract_id)
                 devices = []
                 for device in api_devices or []:
                     if not device.device_number or not device.device_code:
@@ -129,7 +133,7 @@ class IecDataFetcher:
                             device_type=device.device_type or 0,
                             device_number=device.device_number,
                             device_code=device.device_code,
-                            meter_kind="Consumption",
+                            meter_kind=meter_kind,
                         )
                     )
                 self._devices_by_contract_id[contract_id] = devices
@@ -140,6 +144,49 @@ class IecDataFetcher:
                 )
                 devices = []
         return devices or []
+
+    async def _get_meter_kind_for_contract(self, contract_id: int) -> str:
+        """Return the remote reading meter kind for a contract.
+
+        Private producers (e.g. solar) have bidirectional meters, so their
+        readings must be requested with "Backstream" to get export data.
+        Falls back to "Consumption" when the producer status is unknown.
+        """
+        bp_number = self._get_bp_number_for_contract(contract_id)
+        if not bp_number:
+            return "Consumption"
+
+        contracts = self._contracts_by_bp_number.get(bp_number, _MISSING)
+        if contracts is _MISSING:
+            try:
+                contracts = await self._api_call(
+                    self.api.get_contracts(bp_number)
+                )
+            except IECError:
+                _LOGGER.exception(
+                    "Failed fetching contracts for BP number %s",
+                    bp_number,
+                )
+                contracts = []
+            self._contracts_by_bp_number[bp_number] = contracts
+
+        for contract in contracts or []:
+            if contract.contract_id and int(contract.contract_id) == contract_id:
+                return (
+                    "Backstream" if contract.from_private_producer else "Consumption"
+                )
+        return "Consumption"
+
+    def _get_bp_number_for_contract(self, contract_id: int) -> str | None:
+        """Return the BP number associated with a contract id."""
+        bp_number_to_contract = self._config_entry.data.get(
+            CONF_BP_NUMBER_TO_CONTRACT
+        )
+        if isinstance(bp_number_to_contract, dict):
+            for bp_number, contract_ids in bp_number_to_contract.items():
+                if contract_id in {int(c) for c in contract_ids}:
+                    return self._normalize_bp_number(str(bp_number))
+        return self._normalize_bp_number(self._config_entry.data.get(CONF_BP_NUMBER))
 
     async def _get_devices_by_device_id(self, meter_id: str) -> Devices | None:
         """Fetch device details by meter ID, cached per cycle."""
@@ -567,6 +614,7 @@ class IecDataFetcher:
         """Clear all per-update-cycle caches. Called after each update cycle."""
         self._today_readings = {}
         self._devices_by_contract_id = {}
+        self._contracts_by_bp_number = {}
         self._readings = {}
         self._last_meter_reading = {}
         self._kwh_tariff = _MISSING

--- a/custom_components/iec/sensor.py
+++ b/custom_components/iec/sensor.py
@@ -316,6 +316,29 @@ SMART_ELEC_SENSORS: tuple[IecEntityDescription, ...] = (
             )
         ),
     ),
+    IecMeterEntityDescription(
+        key="elec_consumption_since_last_invoice",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data[FUTURE_CONSUMPTIONS_DICT_NAME][
+                data[ATTRIBUTES_DICT_NAME][METER_ID_ATTR_NAME]
+            ].future_consumption
+            if (
+                data[FUTURE_CONSUMPTIONS_DICT_NAME]
+                and data[FUTURE_CONSUMPTIONS_DICT_NAME].get(
+                    data[ATTRIBUTES_DICT_NAME][METER_ID_ATTR_NAME]
+                )
+                and data[FUTURE_CONSUMPTIONS_DICT_NAME][
+                    data[ATTRIBUTES_DICT_NAME][METER_ID_ATTR_NAME]
+                ].future_consumption
+                is not None
+            )
+            else None
+        ),
+    ),
 )
 
 BACKSTREAM_ELEC_SENSORS: tuple[IecEntityDescription, ...] = (
@@ -420,9 +443,7 @@ ELEC_SENSORS: tuple[IecEntityDescription, ...] = (
         key="iec_bill_last_payment_date",
         device_class=SensorDeviceClass.DATE,
         value_fn=lambda data: (
-            _parse_invoice_last_date(
-                data[INVOICE_DICT_NAME].last_date
-            )
+            _parse_invoice_last_date(data[INVOICE_DICT_NAME].last_date)
             if (data[INVOICE_DICT_NAME] != EMPTY_INVOICE)
             else None
         ),

--- a/tests/coordinator/test_invoice_reading_dates.py
+++ b/tests/coordinator/test_invoice_reading_dates.py
@@ -15,8 +15,8 @@ from custom_components.iec.bill import _get_invoice_reading_dates
 class FakeInvoice:
     """Minimal stand-in for an iec_api invoice model."""
 
-    last_date: str
-    to_date: datetime | None
+    full_date: datetime
+    to_date: datetime | None = None
 
 
 def test_next_invoice_with_none_to_date_does_not_crash():
@@ -24,41 +24,43 @@ def test_next_invoice_with_none_to_date_does_not_crash():
 
     Regression test for: TypeError: combine() argument 1 must be
     datetime.date, not None. Occurred whenever the invoice following the
-    most-recent-past invoice (by lastDate) had a to_date of None, e.g. the
+    most-recent-past invoice (by fullDate) had a to_date of None, e.g. the
     current, not-yet-closed billing period.
     """
     invoices = [
-        FakeInvoice(last_date="15/07/2026", to_date=None),
-        FakeInvoice(last_date="15/06/2026", to_date=None),
+        FakeInvoice(full_date=datetime(2026, 7, 1)),
+        FakeInvoice(full_date=datetime(2026, 6, 1)),
     ]
 
     last_invoice_date, from_date = _get_invoice_reading_dates(invoices)
 
-    assert last_invoice_date == datetime(2026, 7, 15)
+    assert last_invoice_date == datetime(2026, 7, 2)
     assert from_date == datetime.combine(date.today(), time.min)
 
 
 def test_next_invoice_with_date_to_date_is_combined():
     """A plain date to_date is combined with midnight, as before."""
     invoices = [
-        FakeInvoice(last_date="15/07/2026", to_date=None),
-        FakeInvoice(last_date="15/06/2026", to_date=date(2026, 6, 15)),
+        FakeInvoice(full_date=datetime(2026, 7, 1)),
+        FakeInvoice(full_date=datetime(2026, 6, 1), to_date=date(2026, 6, 15)),
     ]
 
     last_invoice_date, from_date = _get_invoice_reading_dates(invoices)
 
-    assert last_invoice_date == datetime(2026, 7, 15)
+    assert last_invoice_date == datetime(2026, 7, 2)
     assert from_date == datetime(2026, 6, 15)
 
 
 def test_next_invoice_with_datetime_to_date_is_used_directly():
     """A datetime to_date is passed through unchanged, as before."""
     invoices = [
-        FakeInvoice(last_date="15/07/2026", to_date=None),
-        FakeInvoice(last_date="15/06/2026", to_date=datetime(2026, 6, 15, 12, 30)),
+        FakeInvoice(full_date=datetime(2026, 7, 1)),
+        FakeInvoice(
+            full_date=datetime(2026, 6, 1), to_date=datetime(2026, 6, 15, 12, 30)
+        ),
     ]
 
     last_invoice_date, from_date = _get_invoice_reading_dates(invoices)
 
-    assert last_invoice_date == datetime(2026, 7, 15)
+    assert last_invoice_date == datetime(2026, 7, 2)
     assert from_date == datetime(2026, 6, 15, 12, 30)

--- a/tests/test_bill.py
+++ b/tests/test_bill.py
@@ -30,6 +30,12 @@ class TestIsBackstreamMeterKind:
     def test_string_backstream_returns_true(self):
         assert _is_backstream_meter_kind("BackStream") is True
 
+    def test_string_backstream_canonical_returns_true(self):
+        assert _is_backstream_meter_kind("Backstream") is True
+
+    def test_string_consumption_returns_false(self):
+        assert _is_backstream_meter_kind("Consumption") is False
+
     def test_string_hebrew_returns_true(self):
         assert _is_backstream_meter_kind("דו כיווני") is True
 

--- a/tests/test_bill.py
+++ b/tests/test_bill.py
@@ -33,6 +33,9 @@ class TestIsBackstreamMeterKind:
     def test_string_hebrew_returns_true(self):
         assert _is_backstream_meter_kind("דו כיווני") is True
 
+    def test_string_hebrew_hyphen_returns_true(self):
+        assert _is_backstream_meter_kind("דו-כיווני") is True
+
     def test_none_returns_false(self):
         assert _is_backstream_meter_kind(None) is False
 
@@ -58,7 +61,10 @@ class TestMapMeterKind:
         assert _map_meter_kind_to_remote_reading_param("צריכה") == "Consumption"
 
     def test_backstream_hebrew(self):
-        assert _map_meter_kind_to_remote_reading_param("דו כיווני") == "BackStream"
+        assert _map_meter_kind_to_remote_reading_param("דו כיווני") == "Backstream"
+
+    def test_backstream_hebrew_hyphen(self):
+        assert _map_meter_kind_to_remote_reading_param("דו-כיווני") == "Backstream"
 
     def test_none_returns_empty(self):
         assert _map_meter_kind_to_remote_reading_param(None) == ""
@@ -66,8 +72,11 @@ class TestMapMeterKind:
     def test_english_identity(self):
         assert _map_meter_kind_to_remote_reading_param("Consumption") == "Consumption"
 
-    def test_unknown_identity(self):
-        assert _map_meter_kind_to_remote_reading_param("SomeKind") == "SomeKind"
+    def test_english_backstream(self):
+        assert _map_meter_kind_to_remote_reading_param("BackStream") == "Backstream"
+
+    def test_unknown_returns_consumption(self):
+        assert _map_meter_kind_to_remote_reading_param("SomeKind") == "Consumption"
 
     def test_enum_like(self):
         obj = MagicMock()

--- a/tests/test_bill.py
+++ b/tests/test_bill.py
@@ -255,8 +255,10 @@ class TestParseInvoiceLastDate:
 class TestGetInvoiceReadingDates:
     """Contract: the reading window derives from the most recent PAST invoice.
 
-    Invoices whose lastDate is in the future are ignored; the from_date is the
-    to_date of the next older invoice (or today when none exists).
+    Invoices whose fullDate is in the future are ignored; the from_date is the
+    to_date of the next older invoice (or today when none exists). The
+    last_invoice_date sent to IEC is fullDate + 1 day, which is the only value
+    that returns real (non-zeroed) export data for the current period.
     """
 
     def test_empty_invoices(self):
@@ -268,59 +270,59 @@ class TestGetInvoiceReadingDates:
     @freeze_time("2024-06-15")
     def test_single_invoice_current(self):
         invoice = MagicMock()
-        invoice.last_date = "10/06/2024"
+        invoice.full_date = datetime(2024, 6, 1)
         invoice.to_date = datetime(2024, 6, 10)
         last_date, from_date = _get_invoice_reading_dates([invoice])
-        assert last_date == datetime(2024, 6, 10, 0, 0)
+        assert last_date == datetime(2024, 6, 2, 0, 0)
         assert from_date == datetime(2024, 6, 15, 0, 0)
 
     @freeze_time("2024-03-15")
     def test_future_invoice_skipped(self):
         future = MagicMock()
-        future.last_date = "20/06/2024"
+        future.full_date = datetime(2024, 7, 1)
         current = MagicMock()
-        current.last_date = "10/03/2024"
+        current.full_date = datetime(2024, 3, 1)
         current.to_date = datetime(2024, 3, 10)
         last_date, from_date = _get_invoice_reading_dates([future, current])
-        assert last_date == datetime(2024, 3, 10, 0, 0)
+        assert last_date == datetime(2024, 3, 2, 0, 0)
         assert from_date == datetime(2024, 3, 15, 0, 0)
 
     @freeze_time("2024-06-15")
     def test_only_future_invoices_return_none(self):
         """Contract: invoices entirely in the future yield no reading window."""
         future1 = MagicMock()
-        future1.last_date = "20/06/2024"
+        future1.full_date = datetime(2024, 7, 1)
         future2 = MagicMock()
-        future2.last_date = "25/06/2024"
+        future2.full_date = datetime(2024, 7, 5)
         assert _get_invoice_reading_dates([future1, future2]) == (None, None)
 
     @freeze_time("2024-06-15")
     def test_only_past_invoices_uses_most_recent(self):
         """Contract: the most recent past invoice sets the window start."""
         older = MagicMock()
-        older.last_date = "01/01/2024"
+        older.full_date = datetime(2024, 1, 1)
         older.to_date = datetime(2024, 1, 1)
         newer = MagicMock()
-        newer.last_date = "01/06/2024"
+        newer.full_date = datetime(2024, 6, 1)
         newer.to_date = datetime(2024, 6, 1)
         last_date, from_date = _get_invoice_reading_dates([older, newer])
-        assert last_date == datetime(2024, 6, 1, 0, 0)
+        assert last_date == datetime(2024, 6, 2, 0, 0)
         # from_date comes from the next older invoice's to_date.
         assert from_date == datetime(2024, 1, 1, 0, 0)
 
     @freeze_time("2024-06-15")
-    def test_mixed_ordering_is_sorted_by_last_date(self):
-        """Contract: input order must not matter; sorted by lastDate desc."""
+    def test_mixed_ordering_is_sorted_by_full_date(self):
+        """Contract: input order must not matter; sorted by fullDate desc."""
         newest = MagicMock()
-        newest.last_date = "10/06/2024"
+        newest.full_date = datetime(2024, 6, 1)
         oldest = MagicMock()
-        oldest.last_date = "10/01/2024"
+        oldest.full_date = datetime(2024, 1, 1)
         middle = MagicMock()
-        middle.last_date = "10/04/2024"
+        middle.full_date = datetime(2024, 4, 1)
         middle.to_date = datetime(2024, 4, 10)
         # Unsorted input on purpose
         last_date, from_date = _get_invoice_reading_dates([oldest, newest, middle])
-        assert last_date == datetime(2024, 6, 10, 0, 0)
+        assert last_date == datetime(2024, 6, 2, 0, 0)
         assert from_date == datetime(2024, 4, 10, 0, 0)
 
     @freeze_time("2024-06-15")
@@ -331,12 +333,12 @@ class TestGetInvoiceReadingDates:
         is still open; the function must fall back to today instead of raising.
         """
         current = MagicMock()
-        current.last_date = "10/03/2024"
+        current.full_date = datetime(2024, 3, 1)
         next_invoice = MagicMock()
-        next_invoice.last_date = "10/02/2024"
+        next_invoice.full_date = datetime(2024, 2, 1)
         next_invoice.to_date = None
         last_date, from_date = _get_invoice_reading_dates([current, next_invoice])
-        assert last_date == datetime(2024, 3, 10, 0, 0)
+        assert last_date == datetime(2024, 3, 2, 0, 0)
         assert from_date == datetime(2024, 6, 15, 0, 0)  # falls back to today
 
 

--- a/tests/test_bill.py
+++ b/tests/test_bill.py
@@ -10,14 +10,20 @@ from custom_components.iec.bill import (
     _build_backstream_totals,
     _calculate_estimated_bill,
     _extract_valid_future_consumption,
+    _future_consumption_candidate_dates,
     _get_invoice_reading_dates,
     _is_backstream_meter_kind,
     _map_meter_kind_to_remote_reading_param,
+    _needs_future_consumption_fallback,
     _parse_invoice_last_date,
     _select_meter_data,
 )
 from custom_components.iec.const import EMPTY_INVOICE
-from iec_api.models.remote_reading import FutureConsumptionInfo, MeterReadingData
+from iec_api.models.remote_reading import (
+    FutureConsumptionInfo,
+    MeterReadingData,
+    ReadingResolution,
+)
 
 
 class TestIsBackstreamMeterKind:
@@ -121,6 +127,64 @@ class TestBuildBackstreamTotals:
         info.total_export = 200.0
         result = _build_backstream_totals(info)
         assert result == {"total_back_stream_for_period": 100.0, "total_export": 200.0}
+
+
+class TestNeedsFutureConsumptionFallback:
+    def _future_info(self, consumption=100.0):
+        info = MagicMock(spec=FutureConsumptionInfo)
+        info.future_consumption = consumption
+        return info
+
+    def test_missing_future_consumption_returns_true(self):
+        assert _needs_future_consumption_fallback({}, {}, {}, "m1") is True
+
+    def test_none_future_consumption_returns_true(self):
+        assert _needs_future_consumption_fallback({"m1": None}, {}, {}, "m1") is True
+
+    def test_consumption_meter_with_data_returns_false(self):
+        future_consumption = {"m1": self._future_info()}
+        assert (
+            _needs_future_consumption_fallback(
+                future_consumption,
+                {"m1": False},
+                {"m1": {"total_export": 0.0}},
+                "m1",
+            )
+            is False
+        )
+
+    def test_backstream_meter_zero_export_returns_true(self):
+        future_consumption = {"m1": self._future_info()}
+        assert (
+            _needs_future_consumption_fallback(
+                future_consumption,
+                {"m1": True},
+                {"m1": {"total_export": 0.0}},
+                "m1",
+            )
+            is True
+        )
+
+    def test_backstream_meter_missing_totals_returns_true(self):
+        future_consumption = {"m1": self._future_info()}
+        assert (
+            _needs_future_consumption_fallback(
+                future_consumption, {"m1": True}, {}, "m1"
+            )
+            is True
+        )
+
+    def test_backstream_meter_with_real_export_returns_false(self):
+        future_consumption = {"m1": self._future_info()}
+        assert (
+            _needs_future_consumption_fallback(
+                future_consumption,
+                {"m1": True},
+                {"m1": {"total_export": 39225.556}},
+                "m1",
+            )
+            is False
+        )
 
 
 class TestSelectMeterData:
@@ -534,3 +598,39 @@ class TestCalculateEstimatedBill:
         assert delivery == pytest.approx(10.0)
         assert fixed == pytest.approx(35.27)
         assert total_est == pytest.approx(35.27)
+
+
+class TestFutureConsumptionCandidateDates:
+    def test_returns_five_candidates_newest_first(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 10))
+        assert [resolution for _, resolution in candidates] == [
+            ReadingResolution.DAILY,
+            ReadingResolution.DAILY,
+            ReadingResolution.DAILY,
+            ReadingResolution.WEEKLY,
+            ReadingResolution.MONTHLY,
+        ]
+
+    def test_daily_candidates_are_last_three_days(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 10))
+        assert [req_date for req_date, _ in candidates[:3]] == [
+            datetime(2026, 8, 10),
+            datetime(2026, 8, 9),
+            datetime(2026, 8, 8),
+        ]
+
+    def test_monday_weekly_candidate_is_previous_sunday(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 10))
+        assert candidates[3] == (datetime(2026, 8, 9), ReadingResolution.WEEKLY)
+
+    def test_sunday_weekly_candidate_is_two_sundays_ago(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 9))
+        assert candidates[3] == (datetime(2026, 8, 2), ReadingResolution.WEEKLY)
+
+    def test_non_first_of_month_monthly_candidate_is_current_month_first(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 9))
+        assert candidates[4] == (datetime(2026, 8, 1), ReadingResolution.MONTHLY)
+
+    def test_first_of_month_monthly_candidate_is_previous_month_first(self):
+        candidates = _future_consumption_candidate_dates(datetime(2026, 8, 1))
+        assert candidates[4] == (datetime(2026, 7, 1), ReadingResolution.MONTHLY)

--- a/tests/test_bill.py
+++ b/tests/test_bill.py
@@ -78,10 +78,30 @@ class TestMapMeterKind:
     def test_unknown_returns_consumption(self):
         assert _map_meter_kind_to_remote_reading_param("SomeKind") == "Consumption"
 
+    def test_int_2_returns_backstream(self):
+        assert _map_meter_kind_to_remote_reading_param(2) == "Backstream"
+
+    def test_int_1_returns_consumption(self):
+        assert _map_meter_kind_to_remote_reading_param(1) == "Consumption"
+
+    def test_int_3_returns_consumption(self):
+        assert _map_meter_kind_to_remote_reading_param(3) == "Consumption"
+
+    def test_string_2_returns_backstream(self):
+        assert _map_meter_kind_to_remote_reading_param("2") == "Backstream"
+
+    def test_string_1_returns_consumption(self):
+        assert _map_meter_kind_to_remote_reading_param("1") == "Consumption"
+
     def test_enum_like(self):
         obj = MagicMock()
         obj.value = "צריכה"
         assert _map_meter_kind_to_remote_reading_param(obj) == "Consumption"
+
+    def test_enum_like_with_numeric_value(self):
+        obj = MagicMock()
+        obj.value = 2
+        assert _map_meter_kind_to_remote_reading_param(obj) == "Backstream"
 
 
 class TestBuildBackstreamTotals:
@@ -345,7 +365,16 @@ class TestCalculateEstimatedBill:
             last_invoice=MagicMock(),
         )
         assert len(result) == 8
-        total_est, fixed, consumption_price, days, delivery, distribution, kva, fut_cons = result
+        (
+            total_est,
+            fixed,
+            consumption_price,
+            days,
+            delivery,
+            distribution,
+            kva,
+            fut_cons,
+        ) = result
         assert days >= 1
         assert isinstance(total_est, float)
         assert isinstance(consumption_price, float)
@@ -364,7 +393,16 @@ class TestCalculateEstimatedBill:
             power_size=25.0,
             last_invoice=EMPTY_INVOICE,
         )
-        total_est, fixed, consumption_price, days, delivery, distribution, kva, fut_cons = result
+        (
+            total_est,
+            fixed,
+            consumption_price,
+            days,
+            delivery,
+            distribution,
+            kva,
+            fut_cons,
+        ) = result
         assert isinstance(total_est, float)
 
     @freeze_time("2024-06-15")
@@ -472,7 +510,16 @@ class TestCalculateEstimatedBill:
             power_size=25.0,
             last_invoice=EMPTY_INVOICE,
         )
-        total_est, fixed, consumption_price, days, delivery, distribution, kva, fut_cons = result
+        (
+            total_est,
+            fixed,
+            consumption_price,
+            days,
+            delivery,
+            distribution,
+            kva,
+            fut_cons,
+        ) = result
         assert fut_cons == 0.0
         assert consumption_price == 0.0
         assert days == 15  # frozen at 2024-06-15


### PR DESCRIPTION
## Summary

Fixes #507 — backstream (energy production) data is no longer available or is zeroed in sensors. Also adds a new `Consumption since last invoice` sensor.

## Root causes

Two separate problems caused backstream/export data to be missing or zeroed:

**1. Meter kind was hardcoded to `"Consumption"`**
Commit `808b967` (#465) hardcoded `meter_kind="Consumption"` for every device when working around the DeviceIn endpoint's recaptcha requirement. For cookie-less API clients like Home Assistant, the request's `meterKind` is the gate that determines whether backstream/export data is returned:

- Request `meterKind:"Consumption"` → response has `meterKind:1`, all backstream/export fields zeroed
- Request `meterKind:"Backstream"` → response has `meterKind:2` with real backstream/export data (byte-identical to what the IEC web app receives)

**2. Zeroed export data on monthly readings**
Even with the correct meter kind, the IEC API returns zeroed export data for the current period unless `lastInvoiceDate` is the day after the last invoice. The coordinator only sent `last_invoice_date` on the first-of-month/Sunday path, so the regular monthly "latest reading" request sent the period start as `lastInvoiceDate` and the API zeroed out all export fields.

## Changes

**`data_fetcher.py`** — `_get_devices_by_contract_id` no longer hardcodes `meter_kind="Consumption"`. New `_get_meter_kind_for_contract()` derives the meter kind from the contract's `from_private_producer` flag, fetched cookie-less via `get_contracts()` (cached per refresh cycle; on `IECError` falls back to `"Consumption"`). The DeviceIn endpoint cannot be used here — that's exactly why #465 replaced it.

**`bill.py`** —
- `_map_meter_kind_to_remote_reading_param` now normalizes Hebrew/English inputs to the exact API casing the IEC web app sends: `"דו כיווני"` / `"דו-כיווני"` → `"Backstream"` (was `"BackStream"` — capital S, which never matches the API), `"צריכה"` → `"Consumption"`, numeric values (1 = Consumption, 2 = Backstream), and unknown values default to `"Consumption"`.
- `_get_invoice_reading_dates` now derives `lastInvoiceDate` from the most recent invoice's `fullDate + 1 day` (IEC's requirement for non-zeroed export data) instead of the `lastDate` field.
- New `_needs_future_consumption_fallback` and `_future_consumption_candidate_dates` helpers.

**`coordinator.py`** —
- Backstream meters are now classified from the request-side `device.meter_kind` (the contract's private-producer flag). The response `meterKind` flips between 1 and 2 for the same meter depending on the queried period, so it is not a reliable indicator of a bidirectional meter.
- MONTHLY readings always send the invoice-derived `lastInvoiceDate`, keeping `fromDate` as the first of the current month.
- The future-consumption fallback (`_probe_future_consumption`) walks progressively older windows (last 3 days → last completed week → first of month), skipping zero-export windows for backstream meters, instead of a single two-days-ago monthly fetch.

**`sensor.py`** — new meter-level `Consumption since last invoice` sensor (`elec_consumption_since_last_invoice`) reading `future_consumption`, mirroring the existing backstream production sensor. Translations exist in both `en.json` and `he.json`.

**Tests** — updated and extended (`tests/test_bill.py`, `tests/coordinator/test_invoice_reading_dates.py`) for the new casing/defaults, the `fullDate + 1` contract, and the fallback helpers.

## Test plan

- [x] Ruff lint passes (`./scripts/lint`)
- [x] Unit tests pass (`pytest tests/` — 87 passed)
- [x] MyPy type check passes
- [x] Verified against a real private-producer (solar) contract: the monthly request with `lastInvoiceDate=2026-07-02` and `fromDate=2026-08-01` returns real export data (`futureBackStream` 3106.799, `totalExport` 39225.556), matching the IEC web app's displayed "Production: 3107" and "Last read: 39226".