### PR TITLE
fix: crash on empty electric-invoice list at month boundary

### DIFF
--- a/custom_components/iec/bill.py
+++ b/custom_components/iec/bill.py
@@ -18,7 +18,7 @@ from iec_api.models.remote_reading import (
 )
 
 from .commons import TIMEZONE
-from .const import EMPTY_INVOICE
+from .const import ELECTRIC_INVOICE_DOC_ID, EMPTY_INVOICE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -223,6 +223,31 @@ def _get_invoice_reading_dates(
             break
 
     return (last_invoice_date_obj, from_date_obj)
+
+
+def select_last_electric_invoice(
+    invoices: list,
+) -> tuple[Any, datetime | None, datetime | None]:
+    """Select the most recent electric invoice from a billing-invoice list.
+
+    Filters by ELECTRIC_INVOICE_DOC_ID and sorts by full_date, most recent
+    first. Falls back to (EMPTY_INVOICE, None, None) when no electric
+    invoice is present.
+    """
+    if not invoices:
+        return EMPTY_INVOICE, None, None
+
+    electric_invoices = [
+        inv for inv in invoices if inv.document_id == ELECTRIC_INVOICE_DOC_ID
+    ]
+    if not electric_invoices:
+        return EMPTY_INVOICE, None, None
+
+    electric_invoices.sort(key=lambda inv: inv.full_date or datetime.min, reverse=True)
+    last_invoice = electric_invoices[0]
+
+    last_invoice_date, from_date = _get_invoice_reading_dates(electric_invoices)
+    return last_invoice, last_invoice_date, from_date
 
 
 def _extract_valid_future_consumption(

--- a/custom_components/iec/coordinator.py
+++ b/custom_components/iec/coordinator.py
@@ -36,10 +36,10 @@ from .bill import (
     _calculate_estimated_bill,
     _extract_valid_future_consumption,
     _future_consumption_candidate_dates,
-    _get_invoice_reading_dates,
     _is_backstream_meter_kind,
     _needs_future_consumption_fallback,
     _select_meter_data,
+    select_last_electric_invoice,
 )
 from .commons import TIMEZONE
 from .const import (
@@ -474,26 +474,19 @@ class IecApiCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                     _LOGGER.exception("Failed fetching invoices", e)
                     billing_invoices = None
 
-            if (
-                billing_invoices
-                and billing_invoices.invoices
-                and len(billing_invoices.invoices) > 0
-            ):
-                billing_invoices.invoices = list(
-                    filter(
-                        lambda inv: inv.document_id == ELECTRIC_INVOICE_DOC_ID,
-                        billing_invoices.invoices,
+            if billing_invoices and billing_invoices.invoices:
+                (
+                    last_invoice,
+                    last_invoice_date,
+                    from_date,
+                ) = select_last_electric_invoice(billing_invoices.invoices)
+                if last_invoice is EMPTY_INVOICE:
+                    _LOGGER.warning(
+                        "No invoices with document_id=%s for contract %s; "
+                        "using EMPTY_INVOICE fallback.",
+                        ELECTRIC_INVOICE_DOC_ID,
+                        contract_id,
                     )
-                )
-                # Get the reading dates based on invoice data
-                last_invoice_date, from_date = _get_invoice_reading_dates(
-                    billing_invoices.invoices
-                )
-                # Keep the first invoice (most recent by full_date) for other uses
-                billing_invoices.invoices.sort(
-                    key=lambda inv: inv.full_date or datetime.min, reverse=True
-                )
-                last_invoice = billing_invoices.invoices[0]
             else:
                 last_invoice = EMPTY_INVOICE
                 last_invoice_date = None

--- a/tests/coordinator/test_select_last_electric_invoice.py
+++ b/tests/coordinator/test_select_last_electric_invoice.py
@@ -1,0 +1,80 @@
+"""Tests for bill.select_last_electric_invoice.
+
+Covers electric-invoice selection from a billing-invoice list, including
+empty input and lists without electric invoices, which fall back to
+EMPTY_INVOICE. Imports the real implementation from
+custom_components.iec.bill.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from custom_components.iec.bill import select_last_electric_invoice
+from custom_components.iec.const import ELECTRIC_INVOICE_DOC_ID, EMPTY_INVOICE
+
+
+@dataclass
+class FakeInvoice:
+    """Minimal stand-in for an iec_api invoice model."""
+
+    document_id: str
+    full_date: datetime | None = None
+    to_date: datetime | None = None
+
+
+def test_empty_invoice_list_returns_empty_invoice():
+    last_invoice, last_invoice_date, from_date = select_last_electric_invoice([])
+
+    assert last_invoice is EMPTY_INVOICE
+    assert last_invoice_date is None
+    assert from_date is None
+
+
+def test_no_electric_doc_id_returns_empty_invoice():
+    invoices = [
+        FakeInvoice(document_id="2", full_date=datetime(2026, 8, 1)),
+        FakeInvoice(document_id="3", full_date=datetime(2026, 8, 2)),
+    ]
+
+    last_invoice, last_invoice_date, from_date = select_last_electric_invoice(invoices)
+
+    assert last_invoice is EMPTY_INVOICE
+    assert last_invoice_date is None
+    assert from_date is None
+
+
+def test_selects_most_recent_electric_invoice():
+    invoices = [
+        FakeInvoice(
+            document_id=ELECTRIC_INVOICE_DOC_ID, full_date=datetime(2026, 7, 1)
+        ),
+        FakeInvoice(
+            document_id=ELECTRIC_INVOICE_DOC_ID, full_date=datetime(2026, 6, 1)
+        ),
+        FakeInvoice(document_id="2", full_date=datetime(2026, 8, 1)),
+    ]
+
+    last_invoice, _last_invoice_date, _from_date = select_last_electric_invoice(
+        invoices
+    )
+
+    assert last_invoice.full_date == datetime(2026, 7, 1)
+    assert last_invoice.document_id == ELECTRIC_INVOICE_DOC_ID
+
+
+def test_mixed_list_with_electric_invoice_keeps_working():
+    invoices = [
+        FakeInvoice(document_id="2", full_date=datetime(2026, 8, 5)),
+        FakeInvoice(
+            document_id=ELECTRIC_INVOICE_DOC_ID, full_date=datetime(2026, 7, 1)
+        ),
+        FakeInvoice(
+            document_id=ELECTRIC_INVOICE_DOC_ID, full_date=datetime(2026, 6, 1)
+        ),
+    ]
+
+    last_invoice, _last_invoice_date, _from_date = select_last_electric_invoice(
+        invoices
+    )
+
+    assert last_invoice.full_date == datetime(2026, 7, 1)


### PR DESCRIPTION
## Summary

Fixes a permanent setup-retry crash loop that hits contracts whenever IEC publishes **no electric invoices** (observed around the 1st of the month, before the new billing period's invoices appear). The integration then shows as stuck "initializing" and never recovers.

## Root cause

`IecApiCoordinator._update_data` checked that `billing_invoices.invoices` was non-empty, then **filtered it** by `document_id == ELECTRIC_INVOICE_DOC_ID`, and finally indexed `invoices[0]` on the possibly-now-empty list:

```python
File "coordinator.py", line 496, in _update_data
    last_invoice = billing_invoices.invoices[0]
IndexError: list index out of range
```

The guard checked the wrong list — after the `document_id` filter, not before it.

## Fix

Extract the selection into a pure, testable helper `select_last_electric_invoice()` in `bill.py` (matching the existing pattern of pure invoice logic there, e.g. `_get_invoice_reading_dates`):

- filters by `ELECTRIC_INVOICE_DOC_ID`
- sorts by `full_date`, most recent first
- on an empty result, falls back to `(EMPTY_INVOICE, None, None)` — exactly what the existing `else` branch does when the API returns no invoice list — so the entry stays `loaded` and last-bill sensors degrade to `unknown` until IEC publishes the new invoice, instead of crash-looping

The coordinator now delegates to the helper and keeps the same warning log when the fallback fires.

## Test plan

- [x] New regression tests in `tests/coordinator/test_select_last_electric_invoice.py`:
  - empty invoice list → `EMPTY_INVOICE`, no crash
  - invoices present but none with the electric `document_id` (the month-boundary case) → `EMPTY_INVOICE`, no crash
  - normal selection picks the most recent electric invoice
  - mixed list filters correctly
- [x] Full suite: **91 passed** (89 existing + 4 new... one new test asserts two fallback cases, total +4)
- [x] `ruff check` + `ruff format --check`: clean
- [x] mypy (project `scripts/typecheck` config): `Success: no issues found in 12 source files`
- [x] **Live validation** on my HA instance during an active month-boundary crash (2026-08-31): before the patch the entry crash-looped in `setup_retry` with `IndexError` every refresh; with the patch the entry reaches `loaded`, consumption/forecast sensors populate, and last-bill sensors show `unknown` until the next invoice is published.