### PR TITLE
chore(deps): bump iec-api to 0.5.16

### DIFF
--- a/custom_components/iec/manifest.json
+++ b/custom_components/iec/manifest.json
@@ -8,6 +8,6 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/guykh/iec-custom-component/issues",
     "loggers": ["iec_api"],
-    "requirements": ["iec-api==0.5.15"],
+    "requirements": ["iec-api==0.5.16"],
     "version": "0.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ homeassistant==2026.2.0
 # DNS resolver only catches ImportError). aiodns 4.x drops that annotation, so
 # pycares 5.x works once HA is >= 2026.2.0.
 pycares>=5.0.1,<5.1.0
-iec-api==0.5.15
+iec-api==0.5.16
 mypy==2.3.1
 pip>=26.2.1
 ruff>=0.16.5


### PR DESCRIPTION
## Summary

Bump `iec-api` dependency from `0.5.15` to `0.5.16`.

## Changes

- `requirements.txt`: `iec-api==0.5.15` → `iec-api==0.5.16`
- `custom_components/iec/manifest.json`: `iec-api==0.5.15` → `iec-api==0.5.16`

## Validation

- [x] Ruff linter passed
- [x] mypy type checker passed
